### PR TITLE
Use hosted Stripe payment link

### DIFF
--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type Stripe from "stripe";
 import { getStripe } from "@/lib/stripe";
 
 export const runtime = "nodejs";
@@ -22,11 +23,7 @@ export async function POST(req: Request) {
 
     const priceId = process.env.STRIPE_PRICE_ID || process.env.NEXT_PUBLIC_STRIPE_PRICE_ID;
 
-    if (!priceId) {
-      if (!PAYMENT_LINK_URL) {
-        return NextResponse.json({ error: "Payment link not configured" }, { status: 500 });
-      }
-
+    if (!priceId && PAYMENT_LINK_URL) {
       const url = new URL(PAYMENT_LINK_URL);
       if (user.email) url.searchParams.set("prefilled_email", user.email);
       url.searchParams.set("client_reference_id", user.id);
@@ -42,13 +39,25 @@ export async function POST(req: Request) {
       metadata: { supabase_user_id: user.id },
     });
 
+    const lineItem: Stripe.Checkout.SessionCreateParams.LineItem = priceId
+      ? { price: priceId, quantity: 1 }
+      : {
+          price_data: {
+            currency: "usd",
+            product_data: { name: "EduContact Subscription" },
+            recurring: { interval: "month" },
+            unit_amount: 100,
+          },
+          quantity: 1,
+        };
+
     const success_url = `${baseUrl}/dashboard/billing?success=1&session_id={CHECKOUT_SESSION_ID}`;
     const cancel_url = `${baseUrl}/dashboard/billing?canceled=1`;
 
     const session = await stripe.checkout.sessions.create({
       mode: "subscription",
       customer: customer.id,
-      line_items: [{ price: priceId, quantity: 1 }],
+      line_items: [lineItem],
       allow_promotion_codes: true,
       billing_address_collection: "auto",
       success_url,

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -31,7 +31,11 @@ export async function POST(req: Request) {
 
     const priceId = process.env.STRIPE_PRICE_ID || process.env.NEXT_PUBLIC_STRIPE_PRICE_ID;
 
-    if (!priceId && PAYMENT_LINK_URL) {
+    if (!priceId) {
+      if (!PAYMENT_LINK_URL) {
+        return NextResponse.json({ error: "Payment link not configured" }, { status: 500 });
+      }
+
       const url = new URL(PAYMENT_LINK_URL);
       if (user.email) url.searchParams.set("prefilled_email", user.email);
       url.searchParams.set("client_reference_id", user.id);
@@ -39,17 +43,10 @@ export async function POST(req: Request) {
       return NextResponse.json({ url: url.toString() });
     }
 
-    const lineItem: Stripe.Checkout.SessionCreateParams.LineItem = priceId
-      ? { price: priceId, quantity: 1 }
-      : {
-          price_data: {
-            currency: "usd",
-            product_data: { name: "EduContact Subscription" },
-            recurring: { interval: "month" },
-            unit_amount: 100,
-          },
-          quantity: 1,
-        };
+    const lineItem: Stripe.Checkout.SessionCreateParams.LineItem = {
+      price: priceId,
+      quantity: 1,
+    };
 
     const success_url = `${base}/dashboard/billing?success=1&session_id={CHECKOUT_SESSION_ID}`;
     const cancel_url = `${base}/dashboard/billing?canceled=1`;

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -7,7 +7,7 @@ export const runtime = "nodejs";
 const PAYMENT_LINK_URL =
   process.env.STRIPE_PAYMENT_LINK_URL ||
   process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK_URL ||
-  "https://buy.stripe.com/7sYbJ19A23Eb6aGfP9";
+  "https://buy.stripe.com/7sYbJ19A23Eb6aGfP9fbq04";
 
 export async function POST() {
   try {

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -1,49 +1,29 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { getStripe } from "@/lib/stripe";
 
 export const runtime = "nodejs";
 
-export async function POST(req: Request) {
-  try {
-    // Robust base URL from the request (works on localhost/preview/prod)
-    const base = new URL(req.url).origin;
+const PAYMENT_LINK_URL =
+  process.env.STRIPE_PAYMENT_LINK_URL ||
+  process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK_URL ||
+  "https://buy.stripe.com/7sYbJ19A23Eb6aGfP9";
 
+export async function POST() {
+  try {
     const cookieStore = cookies();
     const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
 
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-    const priceId = process.env.STRIPE_PRICE_ID || process.env.NEXT_PUBLIC_STRIPE_PRICE_ID;
-    if (!priceId) return NextResponse.json({ error: "Missing STRIPE_PRICE_ID" }, { status: 500 });
+    if (!PAYMENT_LINK_URL) {
+      return NextResponse.json({ error: "Payment link not configured" }, { status: 500 });
+    }
 
-    const stripe = getStripe();
-
-    // Reuse/create customer by email
-    const existing = await stripe.customers.list({ email: user.email ?? undefined, limit: 1 });
-    const customer = existing.data[0] ?? await stripe.customers.create({
-      email: user.email ?? undefined,
-      metadata: { supabase_user_id: user.id },
-    });
-
-    const success_url = `${base}/dashboard/billing?success=1&session_id={CHECKOUT_SESSION_ID}`;
-    const cancel_url  = `${base}/dashboard/billing?canceled=1`;
-
-    const session = await stripe.checkout.sessions.create({
-      mode: "subscription",
-      customer: customer.id,
-      line_items: [{ price: priceId, quantity: 1 }],
-      allow_promotion_codes: true,
-      billing_address_collection: "auto",
-      success_url,
-      cancel_url,
-      subscription_data: { metadata: { supabase_user_id: user.id } },
-      metadata: { supabase_user_id: user.id },
-    });
-
-    return NextResponse.json({ url: session.url });
+    // With the hosted Stripe Payment Link the session is preconfigured on Stripe's side.
+    // We simply hand the URL back to the client so it can redirect as before.
+    return NextResponse.json({ url: PAYMENT_LINK_URL });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { getStripe } from "@/lib/stripe";
 
 export const runtime = "nodejs";
 
@@ -9,21 +10,54 @@ const PAYMENT_LINK_URL =
   process.env.NEXT_PUBLIC_STRIPE_PAYMENT_LINK_URL ||
   "https://buy.stripe.com/7sYbJ19A23Eb6aGfP9fbq04";
 
-export async function POST() {
+export async function POST(req: Request) {
   try {
+    const baseUrl = new URL(req.url).origin;
+
     const cookieStore = cookies();
     const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
 
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-    if (!PAYMENT_LINK_URL) {
-      return NextResponse.json({ error: "Payment link not configured" }, { status: 500 });
+    const priceId = process.env.STRIPE_PRICE_ID || process.env.NEXT_PUBLIC_STRIPE_PRICE_ID;
+
+    if (!priceId) {
+      if (!PAYMENT_LINK_URL) {
+        return NextResponse.json({ error: "Payment link not configured" }, { status: 500 });
+      }
+
+      const url = new URL(PAYMENT_LINK_URL);
+      if (user.email) url.searchParams.set("prefilled_email", user.email);
+      url.searchParams.set("client_reference_id", user.id);
+
+      return NextResponse.json({ url: url.toString() });
     }
 
-    // With the hosted Stripe Payment Link the session is preconfigured on Stripe's side.
-    // We simply hand the URL back to the client so it can redirect as before.
-    return NextResponse.json({ url: PAYMENT_LINK_URL });
+    const stripe = getStripe();
+
+    const existing = await stripe.customers.list({ email: user.email ?? undefined, limit: 1 });
+    const customer = existing.data[0] ?? await stripe.customers.create({
+      email: user.email ?? undefined,
+      metadata: { supabase_user_id: user.id },
+    });
+
+    const success_url = `${baseUrl}/dashboard/billing?success=1&session_id={CHECKOUT_SESSION_ID}`;
+    const cancel_url = `${baseUrl}/dashboard/billing?canceled=1`;
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      customer: customer.id,
+      line_items: [{ price: priceId, quantity: 1 }],
+      allow_promotion_codes: true,
+      billing_address_collection: "auto",
+      success_url,
+      cancel_url,
+      subscription_data: { metadata: { supabase_user_id: user.id } },
+      metadata: { supabase_user_id: user.id },
+    });
+
+    return NextResponse.json({ url: session.url });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -78,9 +78,11 @@ export default function LandingPage() {
 
       const { data: sessionData } = await supabase.auth.getSession();
       if (sessionData.session) {
-        router.push("/dashboard");
+        router.push("/onboarding/subscribe");
       } else {
-        setNote("Check your email to confirm your account. You can sign in after confirming.");
+        setNote(
+          "Check your email to confirm your account. Once confirmed, you'll be prompted to subscribe for $1/month."
+        );
       }
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Something went wrong.");
@@ -113,6 +115,9 @@ export default function LandingPage() {
             <p className="mt-4 text-lg text-slate-700">
               One-line logs that stay organized, quick filters by student, topic, or method, and
               exports for meetings or documentation — all in seconds.
+            </p>
+            <p className="mt-3 text-base font-semibold text-brand-900">
+              EduContact is just $1 per educator each month after secure Stripe checkout.
             </p>
 
             <div className="mt-6 flex items-center gap-3">
@@ -170,7 +175,7 @@ export default function LandingPage() {
             <p className="mt-1 text-sm muted">
               {mode === "signin"
                 ? "Log contact with families in seconds."
-                : "Start organizing communications in minutes."}
+                : "Start organizing communications in minutes — only $1/month."}
             </p>
 
             <form onSubmit={onSubmit} className="mt-6 space-y-4">
@@ -236,8 +241,8 @@ export default function LandingPage() {
             </form>
 
             <p className="mt-3 text-xs muted">
-              By continuing, you agree to our <a href="#" className="underline">terms</a>. You can sign
-              out anytime in Settings.
+              By continuing, you agree to our <a href="#" className="underline">terms</a>. Subscriptions are
+              $1/month per educator and billed through Stripe. You can sign out anytime in Settings.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the server-created Stripe checkout session with the provided hosted payment link
- keep the existing onboarding redirect flow while allowing configuration via environment variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5ad47462083258241078ef1927777